### PR TITLE
:sparkles: feature: 방송 서비스 페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/heardio/api/radio/application/RadioStationService.java
+++ b/src/main/java/com/heardio/api/radio/application/RadioStationService.java
@@ -1,9 +1,14 @@
 package com.heardio.api.radio.application;
 
 import com.heardio.api.radio.application.dto.CreateRadioStationRequestDto;
+import com.heardio.api.radio.application.dto.GetRadioStationsRequestDto;
+import com.heardio.api.radio.application.dto.GetRadioStationsResponseDto;
 import com.heardio.api.radio.domain.RadioStation;
 import com.heardio.api.radio.domain.repository.RadioStationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,5 +29,9 @@ public class RadioStationService {
         radioStationRepository.save(radioStation);
     }
 
-
+    public GetRadioStationsResponseDto getRadioStations(GetRadioStationsRequestDto request) {
+        PageRequest pageRequest = PageRequest.of(request.page(), request.pageSize(), Sort.by(Sort.Direction.fromString(request.sort().get(1)), request.sort().get(0)));
+        Page<RadioStation> result = radioStationRepository.findAll(pageRequest);
+        return GetRadioStationsResponseDto.from(result);
+    }
 }

--- a/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationResponseDto.java
+++ b/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationResponseDto.java
@@ -1,0 +1,18 @@
+package com.heardio.api.radio.application.dto;
+
+import com.heardio.api.global.asset.RadioStationType;
+import com.heardio.api.radio.domain.RadioStation;
+
+public record GetRadioStationResponseDto(
+        Long radioStationId,
+        RadioStationType radioStationType,
+        String streamUrl,
+        String description
+) {
+    public static GetRadioStationResponseDto from(RadioStation radioStation) {
+        return new GetRadioStationResponseDto(radioStation.getId(),
+                radioStation.getRadioStationType(),
+                radioStation.getStreamUrl(),
+                radioStation.getDescription());
+    }
+}

--- a/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationsRequestDto.java
+++ b/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationsRequestDto.java
@@ -1,0 +1,13 @@
+package com.heardio.api.radio.application.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetRadioStationsRequestDto(
+        int page,
+        int pageSize,
+        List<String> sort
+) {
+}

--- a/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationsResponseDto.java
+++ b/src/main/java/com/heardio/api/radio/application/dto/GetRadioStationsResponseDto.java
@@ -1,0 +1,24 @@
+package com.heardio.api.radio.application.dto;
+
+import com.heardio.api.radio.domain.RadioStation;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record GetRadioStationsResponseDto(
+        List<GetRadioStationResponseDto> list,
+        MetadataDto metadataDto
+) {
+    public record MetadataDto(long totalElements) {
+    }
+
+    public static GetRadioStationsResponseDto from(Page<RadioStation> page) {
+        List<GetRadioStationResponseDto> list = page.getContent().stream()
+                .map(GetRadioStationResponseDto::from)
+                .toList();
+
+        MetadataDto metadataDto = new MetadataDto(page.getTotalElements());
+
+        return new GetRadioStationsResponseDto(list, metadataDto);
+    }
+}

--- a/src/main/java/com/heardio/api/radio/domain/RadioStation.java
+++ b/src/main/java/com/heardio/api/radio/domain/RadioStation.java
@@ -29,15 +29,24 @@ public class RadioStation {
     @Column(name = "description", length = 500)
     private String description;
 
+    @Column(name = "click_count")
+    private long clickCount;
+
     @Builder
     RadioStation(Long id,
                  String stationUuid,
                  RadioStationType radioStationType,
                  String streamUrl,
-                 String description) {
+                 String description,
+                 long clickCount) {
         this.stationUuid = stationUuid;
         this.radioStationType = radioStationType;
         this.streamUrl = streamUrl;
         this.description = description;
+        this.clickCount = clickCount;
+    }
+
+    public void increaseClickCount() {
+        this.clickCount++;
     }
 }

--- a/src/main/java/com/heardio/api/radio/domain/repository/RadioStationRepository.java
+++ b/src/main/java/com/heardio/api/radio/domain/repository/RadioStationRepository.java
@@ -4,4 +4,5 @@ import com.heardio.api.radio.domain.RadioStation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RadioStationRepository extends JpaRepository<RadioStation, Long> {
+
 }

--- a/src/main/java/com/heardio/api/radio/presentation/RadioStationController.java
+++ b/src/main/java/com/heardio/api/radio/presentation/RadioStationController.java
@@ -2,11 +2,15 @@ package com.heardio.api.radio.presentation;
 
 import com.heardio.api.radio.application.RadioStationService;
 import com.heardio.api.radio.application.dto.CreateRadioStationRequestDto;
+import com.heardio.api.radio.application.dto.GetRadioStationsRequestDto;
+import com.heardio.api.radio.application.dto.GetRadioStationsResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "라디오 방송국")
 @RequiredArgsConstructor
@@ -16,9 +20,21 @@ import org.springframework.web.bind.annotation.*;
 public class RadioStationController {
     private final RadioStationService radioStationService;
 
-    @PostMapping
+    @PostMapping("")
     @ResponseStatus(HttpStatus.CREATED)
     public void createRadioStation(@RequestBody CreateRadioStationRequestDto request) {
         radioStationService.createRadioStation(request);
+    }
+
+    @GetMapping("")
+    public GetRadioStationsResponseDto getRadioStations(@RequestParam("page") int page,
+                                                        @RequestParam("pageSize") int pageSize,
+                                                        @RequestParam(value = "sort", defaultValue = "clickCount,desc") List<String> sort) {
+        GetRadioStationsRequestDto request = GetRadioStationsRequestDto.builder()
+                .page(page)
+                .pageSize(pageSize)
+                .sort(sort)
+                .build();
+        return radioStationService.getRadioStations(request);
     }
 }


### PR DESCRIPTION
- page, pageSize, sort 조건 기반 페이징 지원
- 인기순으로 조회될 수 있도록 라디오 클릭수 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 라디오 방송국 목록을 페이지네이션 및 정렬 기준(기본: 클릭수 내림차순)으로 조회할 수 있는 GET API가 추가되었습니다.
  * 각 라디오 방송국의 클릭 수가 저장되고, 클릭 수 증가 기능이 도입되었습니다.

* **기타**
  * 라디오 방송국 목록 및 상세 정보를 위한 응답/요청 데이터 구조가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->