### PR TITLE
:sparkles: feat: 라디오 방송국 정보 수정 API 추가

### DIFF
--- a/src/main/java/com/heardio/api/radio/application/RadioStationService.java
+++ b/src/main/java/com/heardio/api/radio/application/RadioStationService.java
@@ -54,6 +54,7 @@ public class RadioStationService {
 	public void updateRadioStation(Long radioStationId, UpdateRadioStationRequestDto request) {
 		RadioStation radioStation = radioStationRepository.findById(radioStationId)
 			.orElseThrow(() -> new NotFoundException(ErrorCode.RADIO_STATION_NOT_FOUND));
-		radioStation.updateRadioStation(request.radioStationType(), request.streamUrl(), request.description());
+		radioStation.updateRadioStation(request.stationUuid(), request.radioStationType(), request.streamUrl(),
+			request.description());
 	}
 }

--- a/src/main/java/com/heardio/api/radio/application/RadioStationService.java
+++ b/src/main/java/com/heardio/api/radio/application/RadioStationService.java
@@ -12,6 +12,7 @@ import com.heardio.api.radio.application.dto.CreateRadioStationRequestDto;
 import com.heardio.api.radio.application.dto.GetRadioStationResponseDto;
 import com.heardio.api.radio.application.dto.GetRadioStationsRequestDto;
 import com.heardio.api.radio.application.dto.GetRadioStationsResponseDto;
+import com.heardio.api.radio.application.dto.UpdateRadioStationRequestDto;
 import com.heardio.api.radio.domain.RadioStation;
 import com.heardio.api.radio.domain.repository.RadioStationRepository;
 
@@ -47,5 +48,12 @@ public class RadioStationService {
 			.orElseThrow(() -> new NotFoundException(ErrorCode.RADIO_STATION_NOT_FOUND));
 		radioStation.increaseClickCount();
 		return GetRadioStationResponseDto.from(radioStation);
+	}
+
+	@Transactional
+	public void updateRadioStation(Long radioStationId, UpdateRadioStationRequestDto request) {
+		RadioStation radioStation = radioStationRepository.findById(radioStationId)
+			.orElseThrow(() -> new NotFoundException(ErrorCode.RADIO_STATION_NOT_FOUND));
+		radioStation.updateRadioStation(request.radioStationType(), request.streamUrl(), request.description());
 	}
 }

--- a/src/main/java/com/heardio/api/radio/application/dto/UpdateRadioStationRequestDto.java
+++ b/src/main/java/com/heardio/api/radio/application/dto/UpdateRadioStationRequestDto.java
@@ -6,13 +6,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record CreateRadioStationRequestDto(
+public record UpdateRadioStationRequestDto(
 	@NotBlank(message = "방송 서비스 uuid는 필수값입니다.")
 	@Size(max = 36, message = "stationUuid는 최대 36자까지 입력 가능합니다.")
 	String stationUuid,
 	@NotNull(message = "방송 서비스 종류는 필수값입니다.")
 	RadioStationType radioStationType,
-	@NotBlank(message = "스트리밍 url은 필수값입니다.")
 	@Size(max = 300, message = "방송 스트리밍 url은 최대 300자까지 입력 가능합니다.")
 	String streamUrl,
 	@Size(max = 500, message = "description은 최대 500자까지 입력 가능합니다.")

--- a/src/main/java/com/heardio/api/radio/domain/RadioStation.java
+++ b/src/main/java/com/heardio/api/radio/domain/RadioStation.java
@@ -49,4 +49,16 @@ public class RadioStation {
     public void increaseClickCount() {
         this.clickCount++;
     }
+
+    public void updateRadioStation(RadioStationType radioStationType, String streamUrl, String description) {
+        if (radioStationType != null) {
+            this.radioStationType = radioStationType;
+        }
+        if (streamUrl != null && !streamUrl.isBlank()) {
+            this.streamUrl = streamUrl;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
 }

--- a/src/main/java/com/heardio/api/radio/domain/RadioStation.java
+++ b/src/main/java/com/heardio/api/radio/domain/RadioStation.java
@@ -1,7 +1,18 @@
 package com.heardio.api.radio.domain;
 
 import com.heardio.api.global.asset.RadioStationType;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,53 +23,56 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RadioStation {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(name = "station_uuid", length = 36, nullable = false, updatable = false)
-    private String stationUuid;
+	@NotBlank
+	@Size(max = 36)
+	@Column(name = "station_uuid", length = 36, nullable = false)
+	private String stationUuid;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "radio_station_type", length = 50, nullable = false)
-    private RadioStationType radioStationType;
+	@NotNull
+	@Size(max = 50)
+	@Enumerated(EnumType.STRING)
+	@Column(name = "radio_station_type", length = 50, nullable = false)
+	private RadioStationType radioStationType;
 
-    @Column(name = "stream_url", length = 300, nullable = false)
-    private String streamUrl;
+	@NotNull
+	@Size(max = 300)
+	@Column(name = "stream_url", length = 300, nullable = false)
+	private String streamUrl;
 
-    @Column(name = "description", length = 500)
-    private String description;
+	@Size(max = 500)
+	@Column(name = "description", length = 500)
+	private String description;
 
-    @Column(name = "click_count")
-    private long clickCount;
+	@Column(name = "click_count")
+	private long clickCount;
 
-    @Builder
-    RadioStation(Long id,
-                 String stationUuid,
-                 RadioStationType radioStationType,
-                 String streamUrl,
-                 String description,
-                 long clickCount) {
-        this.stationUuid = stationUuid;
-        this.radioStationType = radioStationType;
-        this.streamUrl = streamUrl;
-        this.description = description;
-        this.clickCount = clickCount;
-    }
+	@Builder
+	RadioStation(Long id, String stationUuid, RadioStationType radioStationType, String streamUrl, String description,
+		long clickCount) {
+		this.stationUuid = stationUuid;
+		this.radioStationType = radioStationType;
+		this.streamUrl = streamUrl;
+		this.description = description;
+		this.clickCount = clickCount;
+	}
 
-    public void increaseClickCount() {
-        this.clickCount++;
-    }
+	public void increaseClickCount() {
+		this.clickCount++;
+	}
 
-    public void updateRadioStation(RadioStationType radioStationType, String streamUrl, String description) {
-        if (radioStationType != null) {
-            this.radioStationType = radioStationType;
-        }
-        if (streamUrl != null && !streamUrl.isBlank()) {
-            this.streamUrl = streamUrl;
-        }
-        if (description != null) {
-            this.description = description;
-        }
-    }
+	/**
+	 * 방송국 정보를 업데이트합니다.
+	 * 도메인 규칙을 검증하고 위반 시 예외를 던집니다.
+	 */
+	public void updateRadioStation(String stationUuid, RadioStationType radioStationType, String streamUrl,
+		String description) {
+		this.stationUuid = stationUuid;
+		this.radioStationType = radioStationType;
+		this.streamUrl = streamUrl;
+		this.description = description;
+	}
 }

--- a/src/main/java/com/heardio/api/radio/presentation/RadioStationController.java
+++ b/src/main/java/com/heardio/api/radio/presentation/RadioStationController.java
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +19,7 @@ import com.heardio.api.radio.application.dto.CreateRadioStationRequestDto;
 import com.heardio.api.radio.application.dto.GetRadioStationResponseDto;
 import com.heardio.api.radio.application.dto.GetRadioStationsRequestDto;
 import com.heardio.api.radio.application.dto.GetRadioStationsResponseDto;
+import com.heardio.api.radio.application.dto.UpdateRadioStationRequestDto;
 import com.heardio.api.radio.presentation.api.RadioStationApi;
 
 import lombok.RequiredArgsConstructor;
@@ -55,5 +57,13 @@ public class RadioStationController implements RadioStationApi {
 	@GetMapping("/{radioStationId}")
 	public GetRadioStationResponseDto getRadioStation(@PathVariable("radioStationId") Long radioStationId) {
 		return radioStationService.getRadioStation(radioStationId);
+	}
+
+	@Override
+	@PutMapping("/{radioStationId}")
+	public void updateRadioStation(
+		@PathVariable("radioStationId") Long radioStationId,
+		@RequestBody @Validated UpdateRadioStationRequestDto request) {
+		radioStationService.updateRadioStation(radioStationId, request);
 	}
 }

--- a/src/main/java/com/heardio/api/radio/presentation/api/RadioStationApi.java
+++ b/src/main/java/com/heardio/api/radio/presentation/api/RadioStationApi.java
@@ -6,6 +6,7 @@ import com.heardio.api.global.error.ErrorResponse;
 import com.heardio.api.radio.application.dto.CreateRadioStationRequestDto;
 import com.heardio.api.radio.application.dto.GetRadioStationResponseDto;
 import com.heardio.api.radio.application.dto.GetRadioStationsResponseDto;
+import com.heardio.api.radio.application.dto.UpdateRadioStationRequestDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,12 +22,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "라디오 방송국", description = "라디오 방송국 관련 API")
 public interface RadioStationApi {
 
-	@Operation(summary = "라디오 방송국 생성", description = "새로운 라디오 방송국을 생성합니다.")
+	@Operation(summary = "라디오 방송국 생성", description = "새로운 라디오 방송국을 생성합니다. (어드민 전용)")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "라디오 방송국 생성 성공"
-		),
-		@ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-		)
+		@ApiResponse(responseCode = "201", description = "라디오 방송국 생성 성공"),
+		@ApiResponse(responseCode = "403", description = "권한 없음 (어드민 전용)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 	})
 	void createRadioStation(
 		@Parameter(description = "라디오 방송국 생성 요청 데이터", required = true)
@@ -58,5 +58,19 @@ public interface RadioStationApi {
 	GetRadioStationResponseDto getRadioStation(
 		@Parameter(description = "라디오 방송국 ID", required = true, example = "1")
 		Long radioStationId
+	);
+
+	@Operation(summary = "라디오 방송국 수정", description = "ID로 특정 라디오 방송국의 정보를 수정합니다. (어드민 전용)")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "라디오 방송국 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "권한 없음 (어드민 전용)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "404", description = "라디오 방송국을 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	void updateRadioStation(
+		@Parameter(description = "라디오 방송국 ID", required = true, example = "1")
+		Long radioStationId,
+		@Parameter(description = "라디오 방송국 수정 요청 데이터", required = true)
+		UpdateRadioStationRequestDto request
 	);
 }


### PR DESCRIPTION
- 라디오 방송국 정보 수정 기능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 기존 라디오 스테이션 정보를 수정할 수 있는 기능이 추가되었습니다. 이제 관리자 권한으로 라디오 스테이션의 유형, 스트림 URL, 설명을 업데이트할 수 있습니다.

* **문서화**
  * 라디오 스테이션 생성 및 수정 API의 관리자 전용 안내 및 오류 응답 예시가 추가되었습니다.

* **스타일**
  * 일부 요청 DTO의 코드 들여쓰기가 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->